### PR TITLE
Fix type error in log exception handler.

### DIFF
--- a/toolbox.py
+++ b/toolbox.py
@@ -24,7 +24,7 @@ def log(*args):
 			except:
 				print "?"*len(arg),
 		except:
-			print "["+type(arg)+"]",
+			print "["+str(type(arg))+"]",
 	print
 	loglock.release()
 
@@ -46,7 +46,7 @@ def linelog(*args):
 			except:
 				print "?"*len(arg),
 		except:
-			print "["+type(arg)+"]",
+			print "["+str(type(arg))+"]",
 	loglock.release()
 
 import tkMessageBox


### PR DESCRIPTION
Haven't been able to reproduce the cause of the exception (could have been argument error or something on my end), but noticed this problem when I was playing around with leela_analysis.py and leela_zero_analysis.py.