### PR TITLE
Convert curselection() to int if necessary

### DIFF
--- a/gnugo_analysis.py
+++ b/gnugo_analysis.py
@@ -380,7 +380,7 @@ class GnuGoSettings(BotProfiles):
 
 	def change_selection(self):
 		try:
-			index=self.listbox.curselection()[0]
+			index=int(self.listbox.curselection()[0])
 			self.index=index
 		except:
 			log("No selection")

--- a/gtp_bot.py
+++ b/gtp_bot.py
@@ -64,7 +64,7 @@ class GtpBotSettings(BotProfiles):
 
 	def change_selection(self):
 		try:
-			index=self.listbox.curselection()[0]
+			index=int(self.listbox.curselection()[0])
 			self.index=index
 		except:
 			log("No selection")

--- a/leela_analysis.py
+++ b/leela_analysis.py
@@ -453,7 +453,7 @@ class LeelaSettings(BotProfiles):
 		
 	def change_selection(self):
 		try:
-			index=self.listbox.curselection()[0]
+			index=int(self.listbox.curselection()[0])
 			self.index=index
 		except:
 			log("No selection")

--- a/pachi_analysis.py
+++ b/pachi_analysis.py
@@ -368,7 +368,7 @@ class PachiSettings(BotProfiles):
 		
 	def change_selection(self):
 		try:
-			index=self.listbox.curselection()[0]
+			index=int(self.listbox.curselection()[0])
 			self.index=index
 		except:
 			log("No selection")

--- a/phoenixgo_analysis.py
+++ b/phoenixgo_analysis.py
@@ -525,7 +525,7 @@ class PhoenixGoSettings(BotProfiles):
 		
 	def change_selection(self):
 		try:
-			index=self.listbox.curselection()[0]
+			index=int(self.listbox.curselection()[0])
 			self.index=index
 		except:
 			log("No selection")

--- a/toolbox.py
+++ b/toolbox.py
@@ -2360,7 +2360,7 @@ class BotProfiles(Frame):
 
 	def change_selection(self):
 		try:
-			index=self.listbox.curselection()[0]
+			index=int(self.listbox.curselection()[0])
 			self.index=index
 			log("Profile",index,"selected")
 		except:


### PR DESCRIPTION
In some versions of Tkinter, curselection() returns indices
as strings rather than ints. Therefore, we add a cast to
int to handle this case.

https://bugs.python.org/issue869780
http://effbot.org/tkinterbook/listbox.htm
https://stackoverflow.com/a/54499766/

Without this change, I was originally getting exceptions like the following:

```
Exception in Tkinter callback
Traceback (most recent call last):
  File "/Users/brian/anaconda/lib/python2.7/lib-tk/Tkinter.py", line 1470, in __call__
    return self.func(*args)
  File "/Users/brian/anaconda/lib/python2.7/lib-tk/Tkinter.py", line 531, in callit
    func(*args)
  File "/Users/brian/code/games/goreviewpartner/gnugo_analysis.py", line 389, in change_selection
    data=self.profiles[index]
TypeError: list indices must be integers, not str
```

I am running on MacOS Sierra. Starting Python 2 gives:

```
$ python
Python 2.7.6 |Anaconda 2.0.1 (x86_64)| (default, Nov 11 2013, 10:49:09)
[GCC 4.0.1 (Apple Inc. build 5493)] on darwin
```

Within Python 2, running `import Tkinter; Tkinter._test()` gives a popup that says "This is Tcl/Tk version 8.5". (Test from https://wiki.python.org/moin/TkInter.)